### PR TITLE
Fixed error on Majordomo Alpha:

### DIFF
--- a/modules/phpfm/index.php
+++ b/modules/phpfm/index.php
@@ -2153,7 +2153,7 @@ function chmod_form(){
     </table>
     </form>
     </body>\n</html>";
-}
+}/*
 function get_mime_type($ext = ''){
     $mimes = array(
       'hqx'   =>  'application/mac-binhex40',
@@ -2249,7 +2249,7 @@ function get_mime_type($ext = ''){
       'eml'   =>  'message/rfc822'
     );
     return (!isset($mimes[lowercase($ext)])) ? 'application/octet-stream' : $mimes[lowercase($ext)];
-}
+}*/
 function view_form(){
     global $doc_root,$fm_path_info,$url_info,$current_dir,$is_windows,$filename,$passthru;
     if (intval($passthru)){


### PR DESCRIPTION
Fixed error on Majordomo Alpha:
"http://localhost/modules/phpfm/index.php
Cannot redeclare get_mime_type() (previously declared in /var/www/modules/phpfm/index.php:2157)"
Function "get_mime_type()" was commented in /phpfm/index.php